### PR TITLE
BLD version bump for autopep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,12 @@ python:
     - "3.2"
     - "3.3"
 env:
-  - AUTOPEP8_VERSION=latest
-  - AUTOPEP8_VERSION=master
-matrix:
-  allow_failures:
-    - env: AUTOPEP8_VERSION=latest
+  - AUTOPEP8_VERSION=pypi
+  - AUTOPEP8_VERSION=git
 
 install:
     - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip --quiet install argparse unittest2; fi
-    - if [ "$AUTOPEP8_VERSION" == "master" ]; then pip --quiet install git+git://github.com/hhatto/autopep8.git; fi
+    - if [ "$AUTOPEP8_VERSION" == "git" ]; then pip --quiet install git+git://github.com/hhatto/autopep8.git; fi
     - python setup.py --quiet build --build-base=".build-$TRAVIS_PYTHON_VERSION" install
     - pip install --quiet pytest-cov
     - git config --global user.email "you@example.com"

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def readme():
             return f.read()
 
 INSTALL_REQUIRES = (
-    ['autopep8'] +
+    ['autopep8 >= 1.0.1'] +
     (['argparse'] if version_info < (2, 7) else []) +
-    ['docformatter  >= 0.6']
+    ['docformatter >= 0.6']
 )
 
 setup(


### PR DESCRIPTION
whoop. now all line fixes are in the pypi version of autopep8.

now I have no excuse for release...
