### PR TITLE
Py3 notimplemented bug and empty diff newlines

### DIFF
--- a/pep8radius/pep8radius.py
+++ b/pep8radius/pep8radius.py
@@ -391,7 +391,7 @@ def get_diff(original, fixed, file_name,
                         file_name + '/' + original_label,
                         file_name + '/' + fixed_label,
                         lineterm=newline)
-    text = newline
+    text = ''
     for line in diff:
         text += line
         # Work around missing newline (http://bugs.python.org/issue2142).


### PR DESCRIPTION
previously an empty diff had a new line for each pass. Should obviously just be ''.

(should add unit test for the no lines thing...)
