### PR TITLE
FIX coverage

### DIFF
--- a/pep8radius.py
+++ b/pep8radius.py
@@ -21,6 +21,7 @@ except ImportError:  # pragma: no cover
 if "check_output" not in dir(subprocess):  # pragma: no cover
     # duck punch it in!
     import subprocess
+
     def check_output(*popenargs, **kwargs):
         if 'stdout' in kwargs:  # pragma: no cover
             raise ValueError('stdout argument not allowed, it will be overridden.')

--- a/tests/test_pep8radius.py
+++ b/tests/test_pep8radius.py
@@ -2,13 +2,7 @@ from __future__ import absolute_import
 import autopep8
 from contextlib import contextmanager
 import os
-from pep8radius import (Radius, RadiusGit, RadiusHg,
-                        check_output, parse_args,
-                        which_version_control,
-                        using_git, using_hg,
-                        version, get_diff)
 from shutil import rmtree
-from subprocess import CalledProcessError, STDOUT
 import sys
 
 try:
@@ -23,6 +17,14 @@ else:
 
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
+sys.path.insert(0, ROOT_DIR)
+from pep8radius import (Radius, RadiusGit, RadiusHg,
+                        check_output, CalledProcessError, STDOUT,
+                        parse_args,
+                        which_version_control,
+                        using_git, using_hg,
+                        version, get_diff)
+
 PEP8RADIUS = os.path.join(ROOT_DIR, 'pep8radius.py')
 
 TEMP_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)),


### PR DESCRIPTION
This was an attempt to fix coverage (back to what it was), confusingly moving around the pep8radius.py file seems to have broken coverage, in the sense that where I test with `check_output`:

```
python pep8radius.py --version
```

Is no longer counted against coverage. This doesn't fix that but does fix a different coverage bug which was that it was testing against the installed pep8radius file (so changes required re-installing to test against).
