### PR TITLE
Brute force remove files from temp that don't want to be removed.

### DIFF
--- a/tests/test_pep8radius.py
+++ b/tests/test_pep8radius.py
@@ -312,7 +312,7 @@ class TestRadiusGit(TestRadius, MixinTests):
         try:
             temp_path = os.path.join(TEMP_DIR, '.git')
             rmtree(temp_path)
-        except OSError as e:
+        except OSError as e: # pragma: no cover
         # see http://stackoverflow.com/questions/1213706/what-user-do-python-scripts-run-as-in-windows and http://stackoverflow.com/questions/7228296/permission-change-of-files-in-python
             if e.errno == errno.EACCES:
                 for dirpath, dirnames, filenames in os.walk(temp_path):


### PR DESCRIPTION
Fixes the git error in Issue #64.

Failure was due to files in `temp` being marked as read only.  This http://stackoverflow.com/questions/1213706/what-user-do-python-scripts-run-as-in-windows was a nice start, but the individual files needed to be changed - doesn't appear there's a flag to do that, so manually walk the tree.  http://stackoverflow.com/questions/7228296/permission-change-of-files-in-python

The cleaner way to do this is to define a function for `rmtree` to call on failure, but I only ever get this on the git directory and not the hg, so unless it pops up elsewhere this ugly little kludge should fix things.
