### PR TITLE
Yapf

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,21 @@ of) a branch.
 [![PyPi Monthly Downloads](http://img.shields.io/pypi/dm/pep8radius.svg)](https://pypi.python.org/pypi/pep8radius)
 
 
-Fixing the entire project of PEP8 infractions ("PEP8 storms") can lead to merge conflicts, add noise to merges / pull requests and break (git) blame. pep8radius solves this problem by fixing only those PEP8 infractions incontained on the lines of the project which you've been working, leaving these sections "better than you found it" whilst keeping your commits focused on the areas of the codebase you were actually working on.
+Fixing the entire project of PEP8 infractions ("PEP8 storms") can lead to merge
+conflicts, add noise to merges / pull requests and break (git) blame. pep8radius
+solves this problem by fixing only those PEP8 infractions incontained on the
+lines of the project which you've been working, leaving these sections "better
+than you found it" whilst keeping your commits focused on the areas of the
+codebase you were actually working on.
+
+Requirements
+------------
+pep8radius uses [autopep8](https://pypi.python.org/pypi/autopep8), and in turn
+[pep8](https://pypi.python.org/pypi/pep8). The docformatter option, to fix
+docstrings, uses [docformatter](https://pypi.python.org/pypi/docformatter).
+
+You can also use [yapf](https://pypi.python.org/pypi/yapf) as an alternative
+back-end.
 
 Installation
 ------------
@@ -81,11 +95,50 @@ For example:
 $ git diff master | pep8radius --diff --from-diff=-
 ```
 
-Requirements
+yapf
+----
+To use [yapf](https://pypi.python.org/pypi/yapf) as an alternative back-end, you
+can pass the `--yapf` option:
+```
+$ pep8radius master --diff --yapf
+
+$ pep8radius master --diff --yapf --style=google
+```
+*Note: This ignores autopep8 and docformatter specific arguments.*
+
+Config Files
 ------------
-pep8radius uses [autopep8](https://pypi.python.org/pypi/autopep8), and in turn
-[pep8](https://pypi.python.org/pypi/pep8). The docformatter option, to fix
-docstrings, uses [docformatter](https://pypi.python.org/pypi/docformatter).
+pep8radius looks for configuration files as described in the
+[pep8 docs](http://pep8.readthedocs.org/en/latest/intro.html#configuration).
+
+At the project level, you may have a `setup.cfg` which includes a pep8 section,
+you can use this to define defaults for pep8radius and autopep8:
+
+```
+[pep8]
+rev = master
+ignore = E226,E302,E41
+max-line-length = 160
+```
+
+By default, this will look for a user level default, you can suppress this
+by passing a blank to `global_config`:
+
+```
+[pep8]
+rev = staging
+global_config =
+```
+
+or perhaps you want to use yapf with google style:
+
+```
+[pep8]
+rev = master
+yapf = True
+style = google
+```
+*Note: style can also be a config file, or a dict (see the yapf docs).*
 
 VCS Support
 -----------
@@ -164,6 +217,15 @@ config:
                         don't look for and apply local config files; if not
                         passed, defaults are updated with any config files in
                         the project's root dir
+
+yapf:
+  Options for yapf, alternative to autopep8. Currently any other options are
+  ignored.
+
+  -y, --yapf            Use yapf rather than autopep8. This ignores other
+                        arguments outside of this group.
+  --style               style either pep8, google, name of file with
+                        stylesettings, or a dict
 
 Run before you commit, against a previous commit or branch before merging.
 ```

--- a/pep8radius/__main__.py
+++ b/pep8radius/__main__.py
@@ -1,0 +1,4 @@
+from pep8radius.main import _main
+
+
+_main()

--- a/pep8radius/main.py
+++ b/pep8radius/main.py
@@ -69,9 +69,6 @@ def main(args=None, vc=None, cwd=None, apply_config=False):
                 r = Radius.from_diff(args.from_diff.read(),
                                      options=args, cwd=cwd)
             else:
-                print("oi")
-                import pep8radius
-                print(pep8radius.version)
                 r = Radius(rev=args.rev, options=args, vc=vc, cwd=cwd)
         except NotImplementedError as e:  # pragma: no cover
             print(e)

--- a/pep8radius/main.py
+++ b/pep8radius/main.py
@@ -14,7 +14,7 @@ except ImportError:  # py2, pragma: no cover
 from pep8radius.radius import Radius, RadiusFromDiff
 from pep8radius.shell import CalledProcessError  # with 2.6 compat
 
-__version__ = version = '0.9.1'
+__version__ = version = '0.9.2a0'
 
 
 DEFAULT_IGNORE = 'E24'
@@ -52,13 +52,13 @@ def main(args=None, vc=None, cwd=None, apply_config=False):
             args_set = args  # args is a Namespace
         if '--version' in args_set or getattr(args_set, 'version', 0):
             print(version)
-            sys.exit(0)
+            return 0
         if '--list-fixes' in args_set or getattr(args_set, 'list_fixes', 0):
             from autopep8 import supported_fixes
             for code, description in sorted(supported_fixes()):
                 print('{code} - {description}'.format(
                     code=code, description=description))
-            sys.exit(0)
+            return 0
 
         try:
             try:
@@ -69,16 +69,21 @@ def main(args=None, vc=None, cwd=None, apply_config=False):
                 r = Radius.from_diff(args.from_diff.read(),
                                      options=args, cwd=cwd)
             else:
+                print("oi")
+                import pep8radius
+                print(pep8radius.version)
                 r = Radius(rev=args.rev, options=args, vc=vc, cwd=cwd)
         except NotImplementedError as e:  # pragma: no cover
             print(e)
-            sys.exit(1)
+            return 1
         except CalledProcessError as c:  # pragma: no cover
             # cut off usage and exit
             output = c.output.splitlines()[0]
             print(output)
-            sys.exit(c.returncode)
+            return c.returncode
+
         r.fix()
+        return 0
 
     except KeyboardInterrupt:  # pragma: no cover
         return 1
@@ -180,6 +185,16 @@ def create_parser():
                     'if not passed, defaults are updated with any '
                     "config files in the project's root directory")
 
+    yp = parser.add_argument_group('yapf',
+                                   'Options for yapf, alternative to autopep8. '
+                                   'Currently any other options are ignored.')
+    yp.add_argument('-y', '--yapf', action='store_true',
+                    help='Use yapf rather than autopep8. '
+                    'This ignores other arguments outside of this group.')
+    yp.add_argument('--style', metavar='', default='pep8',
+                    help='style either pep8, google, name of file with style'
+                    'settings, or a dict')
+
     return parser
 
 
@@ -260,7 +275,7 @@ def _split_comma_separated(string):
 def _main(args=None, vc=None, cwd=None):  # pragma: no cover
     if args is None:
         args = sys.argv[1:]
-    return main(args=args, vc=vc, cwd=cwd, apply_config=True)
+    return sys.exit(main(args=args, vc=vc, cwd=cwd, apply_config=True))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/pep8radius/main.py
+++ b/pep8radius/main.py
@@ -14,7 +14,7 @@ except ImportError:  # py2, pragma: no cover
 from pep8radius.radius import Radius, RadiusFromDiff
 from pep8radius.shell import CalledProcessError  # with 2.6 compat
 
-__version__ = version = '0.9.2a0'
+__version__ = version = '0.9.2'
 
 
 DEFAULT_IGNORE = 'E24'

--- a/pep8radius/radius.py
+++ b/pep8radius/radius.py
@@ -68,6 +68,8 @@ class Radius(object):
 
     @staticmethod
     def from_diff(diff, options=None, cwd=None):
+        """Create a Radius object from a diff rather than a reposistory.
+        """
         return RadiusFromDiff(diff=diff, options=options, cwd=cwd)
 
     def modified_lines(self, file_name):
@@ -207,6 +209,10 @@ def fix_code(source_code, line_ranges, options=None, verbose=0):
     if options is None:
         from pep8radius.main import parse_args
         options = parse_args()
+
+    if getattr(options, "yapf", False):
+        from yapf.yapflib.yapf_api import FormatCode
+        return FormatCode(source_code, style_config=options.style, lines=line_ranges)
 
     line_ranges = reversed(line_ranges)
     # Apply line fixes "up" the file (i.e. in reverse) so that

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ INSTALL_REQUIRES = (
     ['autopep8 >= 1.0.4'] +
     (['argparse'] if version_info < (2, 7) else []) +
     ['colorama'] +
-    ['docformatter >= 0.7']
+    ['docformatter >= 0.7'] +
+    ['yapf >= 0.1.5']
 )
 
 setup(


### PR DESCRIPTION
adds cli argument to use yapf (instead of autopep8)

https://github.com/google/yapf

*~~TODO add docs entry, add example .pep8 config (currently there is no config section) you can add in `yapf = True` and `style = ...`~~ (maybe test on some python versions??)*

Waiting on https://github.com/google/yapf/pull/75, then I'll push a release.