### PR TITLE
adding hang-closing to arguments, would not run otherwise

### DIFF
--- a/pep8radius/main.py
+++ b/pep8radius/main.py
@@ -158,6 +158,8 @@ def create_parser():
                     type=int, metavar='n',
                     help='number of spaces per indent level '
                     '(default %(default)s)')
+    ap.add_argument('--hang-closing', default=0,
+                    help='use alternative bracket style for pycodestyle')
 
     df = parser.add_argument_group('docformatter',
                                    'Fix docstrings for PEP257.')


### PR DESCRIPTION
Initial call would not run due to update to autopep8 argument 'hang-closing'. Added argument to pep8radius. 